### PR TITLE
Remove volume mount for config.yml

### DIFF
--- a/templates/homer.xml
+++ b/templates/homer.xml
@@ -21,5 +21,4 @@
   <Labels/>
   <Config Name="Port" Target="8080" Default="" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
   <Config Name="Assets Path" Target="/www/assets" Default="" Mode="rw" Description="Container Path: /www/assets" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/homer/assets/</Config>
-  <Config Name="Config Path" Target="/www/config.yml" Default="" Mode="rw" Description="Container Path: /www/config.yml" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/homer/config/config.yml</Config>
 </Container>


### PR DESCRIPTION
Homer has recently been updated to load config.yml from the assets directory, removing the need to mount it directly.
https://github.com/bastienwirtz/homer/pull/94