### PR TITLE
remove old-v0.2-style CLI call to /bin/archive in archivebox

### DIFF
--- a/templates/archivebox.xml
+++ b/templates/archivebox.xml
@@ -15,7 +15,7 @@ Guide - https://github.com/A75G/docker-templates/blob/master/README.md#first-ins
   <TemplateURL>https://raw.githubusercontent.com/A75G/docker-templates/master/templates/archivebox.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/A75G/docker-templates/master/templates/icons/archivebox.png</Icon>
   <ExtraParams>-it</ExtraParams>
-  <PostArgs>bash -c 'echo "https://github.com/pirate/ArchiveBox" | /bin/archive; tail -f /dev/null'</PostArgs>
+  <PostArgs>server 0.0.0.0:8000</PostArgs>
   <DateInstalled>1596121988</DateInstalled>
   <Description>The self-hosted internet archiver. &#xD;
 Guide - https://github.com/A75G/docker-templates/blob/master/README.md#first-installation (Important)</Description>

--- a/templates/archivebox.xml
+++ b/templates/archivebox.xml
@@ -14,7 +14,7 @@ Guide - https://github.com/A75G/docker-templates/blob/master/README.md#first-ins
   <WebUI>http://[IP]:[PORT:8000]/</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/A75G/docker-templates/master/templates/archivebox.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/A75G/docker-templates/master/templates/icons/archivebox.png</Icon>
-  <ExtraParams>-it</ExtraParams>
+  <ExtraParams>-p 8000</ExtraParams>
   <PostArgs>server 0.0.0.0:8000</PostArgs>
   <DateInstalled>1596121988</DateInstalled>
   <Description>The self-hosted internet archiver. &#xD;


### PR DESCRIPTION
Sorry if I fixed it wrong, not sure exactly what this file is for, but I'm going around fixing all of ArchiveBox's outdated docs and I found this repo with an old CLI call in it.

The new docker container doesn't run this on startup anymore, instead you can run any subcommand like so:

```bash
docker run -v $PWD:/data archivebox init
docker run -v $PWD:/data archivebox add 'https://example.com'
docker run -v $PWD:/data -p 8000 archivebox server 0.0.0.0:8000
# etc.
```