### PR TITLE
Fix project link for wifi-card

### DIFF
--- a/templates/wifi-card.xml
+++ b/templates/wifi-card.xml
@@ -7,7 +7,7 @@
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/89502-support-a75g-repo/</Support>
-  <Project>https://wifi.dev.bdw.to/</Project>
+  <Project>https://github.com/bndw/wifi-card</Project>
   <Overview>Print a neat little card with your WiFi info and stick it on the fridge.</Overview>
   <Category>Other:</Category>
   <WebUI>http://[IP]:[PORT:80]/</WebUI>


### PR DESCRIPTION
The old site was dead and this now points at the GitHub which does also have a link to the new hosted version