### PR TITLE
Update homer with --user param

### DIFF
--- a/templates/homer.xml
+++ b/templates/homer.xml
@@ -13,7 +13,7 @@
   <WebUI>http://[IP]:[PORT:8080]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/A75G/docker-templates/master/templates/homer.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/A75G/docker-templates/master/templates/icons/homer.png</Icon>
-  <ExtraParams/>
+  <ExtraParams>--user 99:100</ExtraParams>
   <PostArgs/>
   <DonateText/>
   <DonateLink/>


### PR DESCRIPTION
Homer container by default runs user with uid:gid of 1000:1000 but unraid creates appdata folders under uid:gid 99:100. Homer docker will quit on first startup because it can't write its default assets to the appdata folder. --user parameter tells this docker to run uid:gid of 99:100