### PR TITLE
Apprise + Cryptad template updates

### DIFF
--- a/templates/apprise.xml
+++ b/templates/apprise.xml
@@ -16,4 +16,5 @@
   <Description>Apprise API - Push Notifications that work with just about every platform!</Description>
   <Config Name="Port" Target="8000" Default="8000" Mode="tcp" Description="Port" Type="Port" Display="always" Required="true" Mask="false">8000</Config>
   <Config Name="Appdata" Target="/config" Default="/mnt/user/appdata/apprise/" Mode="rw" Description="Appdata" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/apprise/</Config>
+  <Config Name="APPRISE_WORKER_COUNT" Target="APPRISE_WORKER_COUNT" Default="8" Mode="" Description="Limit the number of workers (by default: 1 + 2 * number of CPUs) to reduce the amount of memory used by the tool" Type="Variable" Display="always" Required="false" Mask="false">8</Config>
 </Container>

--- a/templates/cryptpad.xml
+++ b/templates/cryptpad.xml
@@ -26,4 +26,5 @@
   <Config Name="Data Path" Target="/cryptpad/data" Default="/mnt/user/appdata/cryptpad/data" Mode="rw" Description="Data Path" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/cryptpad/data</Config>
   <Config Name="Datastore Path" Target="/cryptpad/datastore" Default="/mnt/user/appdata/cryptpad/datastore" Mode="rw" Description="Datastore Path" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/cryptpad/datastore</Config>
   <Config Name="Config Path" Target="/cryptpad/config/config.js" Default="/mnt/user/appdata/cryptpad/config/config.js" Mode="rw" Description="Config Path" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/cryptpad/config/config.js</Config>
+  <Config Name="CPAD_CONF" Target="CPAD_CONF" Default="/cryptpad/config/config.js" Mode="" Description="" Type="Variable" Display="always" Required="true" Mask="false">/cryptpad/config/config.js</Config>
 </Container>


### PR DESCRIPTION
Apprise:
Allow control over the number of workers running by default.
By default, the number of workers is "multiprocessing.cpu_count() * 2 + 1", which, for high CPU hosts, creates a lot of copies of the apprise worker and, therefore, memory usage. 

Full details as posted on the [Unraid forum](https://forums.unraid.net/topic/89502-support-a75g-repo/?do=findComment&comment=1349065)

Cryptad:
Added `CPAD_CONF` environment variable that points to the default configuration file, as detailed in https://github.com/cryptpad/cryptpad/blob/70d47193596662b2ee7278d6671b56812f11f821/docker-entrypoint.sh#L16 and described on the [Unraid forum](https://forums.unraid.net/topic/89502-support-a75g-repo/?do=findComment&comment=1347161)